### PR TITLE
Fix for issue #3 - Card back is shown instead of card front in Safari

### DIFF
--- a/source/card-types.css
+++ b/source/card-types.css
@@ -4,6 +4,10 @@
   box-shadow: none;
 }
 
+.react-credit-card--unknown .react-credit-card__logo {
+    visibility: hidden;
+}
+
 .react-credit-card--dankort .react-credit-card__front,
 .react-credit-card--dankort .react-credit-card__back{
   background: #0055C7;

--- a/source/card.css
+++ b/source/card.css
@@ -47,10 +47,11 @@
   overflow: hidden;
   border-radius: 10px;
   background: #DDDDDD;
+  z-index: 0;
 }
 
 .react-credit-card__back{
-  webkit-transform: rotateY(180deg);
+  -webkit-transform: rotateY(180deg);
   -ms-transform: rotateY(180deg);
   transform: rotateY(180deg);
 }


### PR DESCRIPTION
I've added z-index property to card.css to solve safari card back visibility issue.
I've also added visibility: hidden to the card logo when it is unknown to prevent some corrupted UI i got. 
Tested on Safari, Chrome and Firefox
