### PR TITLE
fix, do not validate card type if provide

### DIFF
--- a/build/card.js
+++ b/build/card.js
@@ -100,7 +100,7 @@
           }
         });
       }
-      if (type = validate.cardType(props.number)) {
+      if (type = this.props.type || validate.cardType(props.number)) {
         if (type === "amex") {
           return this.setState({
             type: {

--- a/source/card.cjsx
+++ b/source/card.cjsx
@@ -70,7 +70,7 @@ module.exports = React.createClass
     if !props.number
       return @setState type: name:"unknown", length: 16
 
-    if type = validate.cardType(props.number)
+    if type = @props.type or validate.cardType(props.number)
       if type is "amex"
         return @setState type: name:type, length: 15
       else


### PR DESCRIPTION
Sometimes it's useless to check cart type, ie if you already got it with a stored card (only the four last digit) and want to display something like "•••• •••• •••• 4242". 
