### PR TITLE
Updating payment dependence to ^2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "react": "^0.12.2"
   },
   "dependencies": {
-    "payment": "0.0.5"
+    "payment": "^2.1.0"
   }
 }


### PR DESCRIPTION
This new version of payment solves the "WARNING" problem with webpack:

```
WARNING in ./~/payment/lib/payment.js
Critical dependencies:
1:459-466 This seems to be a pre-built javascript file. Though this is possible, it's not recommended. Try to require the original source to get better results.
 @ ./~/payment/lib/payment.js 1:459-466
```

_BTW: Valew João pelo excelente trabalho. Um Abraço!_
;)
